### PR TITLE
add a design document directory and template

### DIFF
--- a/design/_template.md
+++ b/design/_template.md
@@ -5,106 +5,181 @@
  http://creativecommons.org/licenses/by/3.0/legalcode
 -->
 
-Example Design Document
-=======================
+# Title
 
-Introduction paragraph -- why are we doing anything? A single
-paragraph of prose that users can understand. The title and this first
-paragraph should be used as the subject line and body of the commit
-message respectively.
+This is the title of the design.
+Keep it simple and descriptive.
+
+A good title can help communicate what the design is and should be
+considered as part of any review.
+
+The title should be lowercased and spaces/punctuation should be
+replaced with `-`.
 
 Some notes about the design process:
 
-* Not all changes need a design document. Anything that is likely to
+- Not all changes need a design document. Anything that is likely to
   result in significant review discussion, or changes to user-facing
   documentation, does.
 
-* The aim of this document is first to define the problem we need to
+- The aim of this document is first to define the problem we need to
   solve, and second agree the overall approach to solve that problem.
 
-* This document is not intended to be extensive user-facing
+- This document is not intended to be extensive user-facing
   documentation for a new feature. It should provide enough detail for
   contributors to the project to understand the impact and help refine
   the design.
 
 Some notes about using this template:
 
-* Your spec should be in [Markdown
+- The new document should be in [Markdown
   syntax](https://daringfireball.net/projects/markdown/syntax), like
   this template.
 
-* Please wrap text at 79 columns.
+- Please wrap text at 79 columns.
 
-* Please do not delete any of the sections in this template.  If you have
+- Please do not delete any of the sections in this template.  If you have
   nothing to say for a whole section, just write: None
 
+To get started with this template:
 
-# Problem description #
+1. **Make a copy of this template.**
 
-A detailed description of the problem. What problem is this blueprint
-addressing?
+    Copy this template into the `design` directory and name it
+    `YYYYMMDD-my-title.md`, where `YYYYMMDD` is the date the document
+    was first drafted.
 
-## Use Cases ##
+1. **Fill out the "overview" sections.**
 
-What use cases does this address? What impact on actors does this
-change have?  Ensure you are clear about the actors in each use case:
-Developer, End User, Deployer etc.
+    This includes the Summary and Motivation sections.
 
-# Proposed change #
+1. **Create a PR.**
 
-Here is where you cover the change you propose to make in detail. How
-do you propose to solve this problem?
+1. **Merge early.**
 
-If this is one part of a larger effort make it clear where this piece
-ends. In other words, what's the scope of this effort?
+    Avoid getting hung up on specific details and instead aim to get
+    the goal of the design merged quickly.  The best way to do this is
+    to just start with the "Overview" sections and fill out details
+    incrementally in follow on PRs.  View anything marked as a
+    `provisional` as a working document and subject to change.  Aim
+    for single topic PRs to keep discussions focused.  If you disagree
+    with what is already in a document, open a new PR with suggested
+    changes.
 
-## Alternatives ##
+The canonical place for the latest set of instructions (and the likely
+source of this file) is [here](/designs/_template.md).
 
-What other ways could we solve the problem? Why should we not use
-those approaches? This doesn't have to be a full literature review,
-but it should demonstrate that thought has been put into why the
-proposed solution is an appropriate one.
+## Status
 
-## CRD impact ##
+One of: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
 
-* What new objects is this going to require?
-* What new fields are needed, for either the Spec or Status section?
-* What other changes (labels, annotations, etc.) are needed?
+## Table of Contents
 
-## Security impact ##
+A table of contents is helpful for quickly jumping to sections of a
+design and for highlighting any additional information provided beyond
+the standard template.
 
-Describe any potential security impact on the system.
+[Tools for generating][] a table of contents from markdown are available.
 
-* Does this change touch sensitive data such as credentials or other
-  secret values?
+<!--ts-->
+   * [Title](#title)
+      * [Status](#status)
+      * [Table of Contents](#table-of-contents)
+      * [Summary](#summary)
+      * [Motivation](#motivation)
+         * [Goals](#goals)
+         * [Non-Goals](#non-goals)
+      * [Proposal](#proposal)
+         * [User Stories [optional]](#user-stories-optional)
+            * [Story 1](#story-1)
+            * [Story 2](#story-2)
+         * [Implementation Details/Notes/Constraints [optional]](#implementation-detailsnotesconstraints-optional)
+         * [Risks and Mitigations](#risks-and-mitigations)
+      * [Design Details](#design-details)
+         * [Work Items](#work-items)
+         * [Dependencies](#dependencies)
+         * [Test Plan](#test-plan)
+         * [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+         * [Version Skew Strategy](#version-skew-strategy)
+      * [Drawbacks [optional]](#drawbacks-optional)
+      * [Alternatives [optional]](#alternatives-optional)
+      * [References](#references)
 
-* Does this change involve cryptography or hashing?
+<!-- Added by: stack, at: 2019-02-15T11:41-05:00 -->
 
-* Does this change require the use of any elevated privileges?
+<!--te-->
 
-## Other end user impact ##
+[Tools for generating]: https://github.com/ekalinin/github-markdown-toc
 
-Aside from the API, are there other ways a user will interact with this
-feature?
+## Summary
 
-## Performance Impact ##
+The `Summary` section is important for producing high quality
+user-focused documentation such as release notes or a development
+roadmap.  It should be possible to collect this information before
+implementation begins in order to avoid requiring implementors to
+split their attention between writing release notes and implementing
+the feature itself.  Reviewers should help to ensure that the tone and
+content of the `Summary` section is useful for a wide audience.
 
-Describe any potential performance impact on the system, for example
-how often will new code be called, and is there a major change to the calling
-pattern of existing code.
+A good summary is probably at least a paragraph in length.
 
-# Implementation #
+## Motivation
 
-## Assignee(s) ##
+This section is for explicitly listing the motivation, goals and
+non-goals of this design.  Describe why the change is important and
+the benefits to users, including what problem it solves.
 
-Who is leading the writing of the code?
+### Goals
 
-## Work Items ##
+List the specific goals of the design.
+How will we know that this has succeeded?
+
+### Non-Goals
+
+What is out of scope for this design?
+Listing non-goals helps to focus discussion and make progress.
+
+## Proposal
+
+This is where we get down to the details of what the proposal actually is.
+
+### User Stories [optional]
+
+Detail the things that people will be able to do if the design is
+implemented.  Include as much detail as possible so that people can
+understand the "how" of the system.  The goal here is to make this
+feel real for users without getting bogged down.
+
+#### Story 1
+
+#### Story 2
+
+### Implementation Details/Notes/Constraints [optional]
+
+- What are the caveats to the implementation?
+- What are some important details that didn't come across above.
+- Go in to as much detail as necessary here.
+- This might be a good place to talk about core concepts and how they relate.
+
+### Risks and Mitigations
+
+What are the risks of this proposal and how do we mitigate.  Think
+broadly.  For example, consider both security and how this will impact
+the larger kubernetes ecosystem.
+
+## Design Details
+
+- What will actually need to change in the code?
+- What new objects is this going to require?
+- What new fields are needed, for either the Spec or Status section?
+- What other changes (labels, annotations, etc.) are needed?
+
+### Work Items
 
 Work items or tasks -- break the feature up into the things that need to be
 done to implement it.
 
-## Dependencies ##
+### Dependencies
 
 * Include specific references to work here or in other projects that
   this design either depends on or is related to.
@@ -113,35 +188,59 @@ done to implement it.
   otherwise not included in the code? Or does it depend on a specific
   version of library?
 
+### Test Plan
 
-# Testing #
+Consider the following in developing a test plan for this enhancement:
 
-Please discuss the important scenarios needed to test here, as well as
-specific edge cases we should be ensuring work correctly. For each
-scenario please specify if this requires specialized hardware, a full
-baremetal environment, or can be simulated with virtual machines.
+- Will there be end-to-end and integration tests, in addition to unit
+  tests?
+- How will it be tested in isolation vs. with other components?
 
+No need to outline all of the test cases, just the general strategy.
 
-# Documentation Impact #
+Anything that would count as tricky in the implementation and anything
+particularly challenging to test should be called out.
 
-Which audiences are affected most by this change, and which
-documentation should be updated because of this change? Don't repeat
-details discussed above, but reference them here in the context of
-documentation for multiple audiences.
+All code is expected to have adequate tests.
 
-# References #
+### Upgrade / Downgrade Strategy
+
+If applicable, how will the component be upgraded and downgraded? Make
+sure this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for
+this enhancement:
+
+- What changes (in invocations, configurations, API use, etc.) is an
+  existing cluster required to make on upgrade in order to keep
+  previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an
+  existing cluster required to make on upgrade in order to make use of
+  the enhancement?
+
+### Version Skew Strategy
+
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test
+plan.
+
+## Drawbacks [optional]
+
+Why should this design _not_ be implemented.
+
+## Alternatives [optional]
+
+Similar to the `Drawbacks` section the `Alternatives` section is used
+to highlight and record other possible approaches to delivering the
+value proposed by a design.
+
+## References
 
 Please add any useful references here. You are not required to have any
 reference. Moreover, this specification should still make sense when your
 references are unavailable. Examples of what you could include are:
 
-* Links to mailing list or IRC discussions
-
-* Links to notes from a summit session
-
-* Links to relevant research, if appropriate
-
-* Related specifications as appropriate (e.g.  if it's an EC2 thing, link the
-  EC2 docs)
-
-* Anything else you feel it is worthwhile to refer to
+- Links to mailing list or other discussions
+- Links to relevant research, if appropriate
+- Related designs, as appropriate
+- Anything else you feel it is worthwhile to refer to

--- a/design/_template.md
+++ b/design/_template.md
@@ -51,7 +51,8 @@ To get started with this template:
 
 1. **Fill out the "overview" sections.**
 
-    This includes the Summary and Motivation sections.
+    This includes the Summary and Motivation sections. Remove the
+    boilerplate and instructions as you go.
 
 1. **Create a PR.**
 

--- a/design/_template.md
+++ b/design/_template.md
@@ -1,0 +1,147 @@
+<!--
+ This work is licensed under a Creative Commons Attribution 3.0
+ Unported License.
+
+ http://creativecommons.org/licenses/by/3.0/legalcode
+-->
+
+Example Design Document
+=======================
+
+Introduction paragraph -- why are we doing anything? A single
+paragraph of prose that users can understand. The title and this first
+paragraph should be used as the subject line and body of the commit
+message respectively.
+
+Some notes about the design process:
+
+* Not all changes need a design document. Anything that is likely to
+  result in significant review discussion, or changes to user-facing
+  documentation, does.
+
+* The aim of this document is first to define the problem we need to
+  solve, and second agree the overall approach to solve that problem.
+
+* This document is not intended to be extensive user-facing
+  documentation for a new feature. It should provide enough detail for
+  contributors to the project to understand the impact and help refine
+  the design.
+
+Some notes about using this template:
+
+* Your spec should be in [Markdown
+  syntax](https://daringfireball.net/projects/markdown/syntax), like
+  this template.
+
+* Please wrap text at 79 columns.
+
+* Please do not delete any of the sections in this template.  If you have
+  nothing to say for a whole section, just write: None
+
+
+# Problem description #
+
+A detailed description of the problem. What problem is this blueprint
+addressing?
+
+## Use Cases ##
+
+What use cases does this address? What impact on actors does this
+change have?  Ensure you are clear about the actors in each use case:
+Developer, End User, Deployer etc.
+
+# Proposed change #
+
+Here is where you cover the change you propose to make in detail. How
+do you propose to solve this problem?
+
+If this is one part of a larger effort make it clear where this piece
+ends. In other words, what's the scope of this effort?
+
+## Alternatives ##
+
+What other ways could we solve the problem? Why should we not use
+those approaches? This doesn't have to be a full literature review,
+but it should demonstrate that thought has been put into why the
+proposed solution is an appropriate one.
+
+## CRD impact ##
+
+* What new objects is this going to require?
+* What new fields are needed, for either the Spec or Status section?
+* What other changes (labels, annotations, etc.) are needed?
+
+## Security impact ##
+
+Describe any potential security impact on the system.
+
+* Does this change touch sensitive data such as credentials or other
+  secret values?
+
+* Does this change involve cryptography or hashing?
+
+* Does this change require the use of any elevated privileges?
+
+## Other end user impact ##
+
+Aside from the API, are there other ways a user will interact with this
+feature?
+
+## Performance Impact ##
+
+Describe any potential performance impact on the system, for example
+how often will new code be called, and is there a major change to the calling
+pattern of existing code.
+
+# Implementation #
+
+## Assignee(s) ##
+
+Who is leading the writing of the code?
+
+## Work Items ##
+
+Work items or tasks -- break the feature up into the things that need to be
+done to implement it.
+
+## Dependencies ##
+
+* Include specific references to work here or in other projects that
+  this design either depends on or is related to.
+
+* Does this feature require any new library dependencies or code
+  otherwise not included in the code? Or does it depend on a specific
+  version of library?
+
+
+# Testing #
+
+Please discuss the important scenarios needed to test here, as well as
+specific edge cases we should be ensuring work correctly. For each
+scenario please specify if this requires specialized hardware, a full
+baremetal environment, or can be simulated with virtual machines.
+
+
+# Documentation Impact #
+
+Which audiences are affected most by this change, and which
+documentation should be updated because of this change? Don't repeat
+details discussed above, but reference them here in the context of
+documentation for multiple audiences.
+
+# References #
+
+Please add any useful references here. You are not required to have any
+reference. Moreover, this specification should still make sense when your
+references are unavailable. Examples of what you could include are:
+
+* Links to mailing list or IRC discussions
+
+* Links to notes from a summit session
+
+* Links to relevant research, if appropriate
+
+* Related specifications as appropriate (e.g.  if it's an EC2 thing, link the
+  EC2 docs)
+
+* Anything else you feel it is worthwhile to refer to


### PR DESCRIPTION
This is a start at a template for design documents for larger
metalkube changes, adapted from similar documents used in OpenStack.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>