### PR TITLE
Update slack channel in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ interfaces.
 ## Project Discussion
 
 * [MetalKube Development Mailing List](https://groups.google.com/forum/#!forum/metalkube-dev)
-* #cluster-api on Kubernetes Slack
+* [#cluster-api-baremetal](https://kubernetes.slack.com/messages/CHD49TLE7) on Kubernetes Slack
 
 ## MetalKube Component Overview
 


### PR DESCRIPTION
It's seem that we already change our home from #cluster-api to #cluster-api-baremetal. This PR aims to update slack channel to the new one.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>